### PR TITLE
Making Matlab work out-of the box with COMSOL

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -131,6 +131,10 @@ modules:
       environment:
         set:
           '{name}_ROOT': '{prefix}'
+    comsol:
+      environment:
+        set:
+          MATLABPATH: '{prefix}/mli'
     cuda:
       environment:
         set:

--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -133,7 +133,7 @@ modules:
           '{name}_ROOT': '{prefix}'
     comsol:
       environment:
-        set:
+        prepend_path:
           MATLABPATH: '{prefix}/mli'
     cuda:
       environment:


### PR DESCRIPTION
* setting the MATLABPATH so that Matlab finds the COMSOL Matlab modules

Signed-off-by: Ricardo Silva <ricardo.silva@epfl.ch>