### PR TITLE
Totalview 2017.2.11 to replace 8.15.10-2

### DIFF
--- a/configuration/packages.yaml
+++ b/configuration/packages.yaml
@@ -89,4 +89,4 @@ packages:
   totalview:
     buildable: False
     paths:
-      totalview@8.15.10-2: /ssoft/spack/external/toolworks/totalview.8.15.10-2
+      totalview@2017.2.11: /ssoft/spack/external/toolworks/totalview.2017.2.11

--- a/packages.yaml
+++ b/packages.yaml
@@ -89,7 +89,7 @@ packages:
       - matlab@R2016a
       - mathematica@9.0.1
       - ansys@17.1
-      - totalview@8.15.10-2
+      - totalview@2017.2.11
       - comsol@5.2a
       - gaussian@g09-D.01
       - scala@2.12.1


### PR DESCRIPTION
I know that we shouldn't change things mid release but totalview 8.15 doesn't work with Intel 2017. Plus it's an external package :-)