### PR TITLE
Add local spark scripts to PATH

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -368,6 +368,9 @@ modules:
 
     spark:
       autoload: 'direct'
+      environment:
+        prepend_path:
+          PATH: '/ssoft/spack/scripts/all/spark'
 
     gaussian:
       template: 'modules/group_restricted.lua'


### PR DESCRIPTION
* Fix SL-442: custom spark scripts not available when the spark module is loaded

Signed-off-by: Ricardo Silva <ricardo.silva@epfl.ch>