### PR TITLE
Picard package added

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -173,6 +173,7 @@ packages:
       - tcl@8.6.6
       - tk@8.6.6 ^tcl@8.6.6
       - mercurial@4.1.2 ^python@2.7.13
+      - picard@2.9.2
 
   # Serial code that uses LAPACK
   lapack:


### PR DESCRIPTION
Package depends on jdk -- do I have to do something special?

```
spack spec -Il picard
Input spec
--------------------------------
     rrtayad  picard

Normalized
--------------------------------
     tuckonn  picard
     6fnw7pd      ^jdk@8:

Concretized
--------------------------------
[+]  uenmbyu  picard@2.9.2%gcc@4.8.5 arch=linux-rhel7-x86_E5v2 
[+]  zfpgxnz      ^jdk@8u92%gcc@4.8.5 arch=linux-rhel7-x86_E5v2 
```
