### PR TITLE
mvapich fixes for Cornalin on Fidis/Gacrux (SL-528)

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -308,19 +308,19 @@ modules:
       environment:
         set:
           MV2_RNDV_PROTOCOL: R3
-          MV2_ON_DEMAND_THRESHOLD: 1
 
     'mvapich2 target=x86_E5v4_Mellanox':
       environment:
         set:
           MV2_RNDV_PROTOCOL: R3
           MV2_ON_DEMAND_THRESHOLD: 1
-          MV2_IBA_HCA: mlx5_0
 
     'mvapich2 target=x86_S6g1_Mellanox':
       environment:
         set:
           MV2_RNDV_PROTOCOL: R3
+          MV2_ON_DEMAND_THRESHOLD: 1
+          MV2_IBA_HCA: mlx5_0
 
     ####
     # LAPACK

--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -308,11 +308,14 @@ modules:
       environment:
         set:
           MV2_RNDV_PROTOCOL: R3
+          MV2_ON_DEMAND_THRESHOLD: 1
 
     'mvapich2 target=x86_E5v4_Mellanox':
       environment:
         set:
           MV2_RNDV_PROTOCOL: R3
+          MV2_ON_DEMAND_THRESHOLD: 1
+          MV2_IBA_HCA: mlx5_0
 
     'mvapich2 target=x86_S6g1_Mellanox':
       environment:


### PR DESCRIPTION
* MV2_ON_DEMAND_THRESHOLD set to 1 to always use the "on-demand connection management scheme" (I suspect this is needed due to the change of the Infiniband fabric from UD to CM mode for GPFS.)
* MV2_IBA_HCA set to mlx5_0 on Gacrux to ensure mvapich always picks the correct adapter

Signed-off-by: Ricardo Silva <ricardo.silva@epfl.ch>