### PR TITLE
Using system installed Java run-time and compilers.

### DIFF
--- a/configuration/packages.yaml
+++ b/configuration/packages.yaml
@@ -9,6 +9,11 @@ packages:
     paths:
       openssl@system: /usr/lib64
 
+  jdk:
+    buildable: False
+    paths:
+      jdk@system: /usr
+
   ####
   # Intel compilers and libraries
   ####

--- a/configuration/packages.yaml
+++ b/configuration/packages.yaml
@@ -12,7 +12,7 @@ packages:
   jdk:
     buildable: False
     paths:
-      jdk@system: /usr
+      jdk@8u141-b16: /usr/lib/jvm/jre
 
   ####
   # Intel compilers and libraries


### PR DESCRIPTION
It's OpenJDK disguised as Oracle's JDK.