### PR TITLE
Intel prepends the path where the license file is located in the module

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -236,7 +236,7 @@ modules:
           IFORTCFG: /ssoft/spack/external/intel/config/2018.2/compilers_and_libraries_2018.2.199/icl.cfg
         prepend_path:
           PATH: '/ssoft/spack/external/intel/2018.2/vtune_amplifier_2018.2.0.551022/bin64'
-
+          INTEL_LICENSE_FILE: /ssoft/spack/external/intel/License
     ####
     # MPI
     ####


### PR DESCRIPTION
VTune was not working for users because the path where Intel looks for licenses is different than the one used for compilers. Prepending this path to INTEL_LICENSE_FILE should fix the issue for every Intel
product.