### PR TITLE
Python module files compiled with Intel preload libifcore

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -306,6 +306,15 @@ modules:
           'OPENBLAS_NUM_THREADS': '1'
 
     ####
+    # PYTHON
+    ####
+
+    'python%intel':
+      environment:
+        prepend_path:
+          LD_PRELOAD: /ssoft/spack/external/intel/2018.2/compilers_and_libraries_2018.2.199/linux/compiler/lib/intel64/libifcore.so.5
+
+    ####
     # Other software
     ####
 


### PR DESCRIPTION
A few scipy modules were compiled without linking libifcore. This is probably due to a wrong linking procedure in that python module. A solution that doesn't involve removing code that is potentially used in production is to preload the library on python startup.