### PR TITLE
spack-base docker container

### DIFF
--- a/docker/spack-base/Dockerfile
+++ b/docker/spack-base/Dockerfile
@@ -1,26 +1,31 @@
 FROM centos:7
 
+# Define where spack is installed, and force spack to accept building as root
 ENV SPACK_ROOT=/opt/spack \
     FORCE_UNSAFE_CONFIGURE=1
 
+# Pick up the latest updates to the base image
 RUN yum upgrade -y && \
     yum clean all && rm -rf /var/cache/yum
 
-# To have a system Lmod out of the box
+# Install the EPEL repository to have LMOD, and install other tools spack needs
 RUN yum install -y epel-release && \
     yum clean all && rm -rf /var/cache/yum
-
-RUN yum install -y autoconf automake cmake gcc gcc-c++ gcc-gfortran git make subversion Lmod patch lbzip2 && \
+RUN yum install -y autoconf automake cmake gcc gcc-c++ gcc-gfortran git make \
+                   subversion Lmod patch lbzip2 && \
     yum clean all && rm -rf /var/cache/yum
 
+# Get the current SCITAS release of spack
 RUN mkdir $SPACK_ROOT && \
     curl -s -L \
     https://api.github.com/repos/epfl-scitas/spack/tarball/releases/paien \
     | tar xzC $SPACK_ROOT --strip 1
 
+# Login script which enables spack (in a way that it runs after the lmod one)
 COPY spack.sh /etc/profile.d/z10_spack.sh
 
+# Pre "add" the system compiler to spack so that it works out-of-the-box
 RUN /bin/bash -l -c "spack compiler add"
 
+# Ensure the login scripts are sourced
 CMD /bin/bash -l
-

--- a/docker/spack-base/Dockerfile
+++ b/docker/spack-base/Dockerfile
@@ -1,0 +1,26 @@
+FROM centos:7
+
+ENV SPACK_ROOT=/opt/spack \
+    FORCE_UNSAFE_CONFIGURE=1
+
+RUN yum upgrade -y && \
+    yum clean all && rm -rf /var/cache/yum
+
+# To have a system Lmod out of the box
+RUN yum install -y epel-release && \
+    yum clean all && rm -rf /var/cache/yum
+
+RUN yum install -y autoconf automake cmake gcc gcc-c++ gcc-gfortran git make subversion Lmod patch lbzip2 && \
+    yum clean all && rm -rf /var/cache/yum
+
+RUN mkdir $SPACK_ROOT && \
+    curl -s -L \
+    https://api.github.com/repos/epfl-scitas/spack/tarball/releases/paien \
+    | tar xzC $SPACK_ROOT --strip 1
+
+COPY spack.sh /etc/profile.d/z10_spack.sh
+
+RUN /bin/bash -l -c "spack compiler add"
+
+CMD /bin/bash -l
+

--- a/docker/spack-base/Dockerfile
+++ b/docker/spack-base/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir $SPACK_ROOT && \
     https://api.github.com/repos/epfl-scitas/spack/tarball/releases/paien \
     | tar xzC $SPACK_ROOT
 
-RUN ln -sfn $SPACK_ROOT/*/* $SPACK_ROOT/
+RUN ln -sfnv $SPACK_ROOT/*/* $SPACK_ROOT/
 
 # Login script which enables spack (in a way that it runs after the lmod one)
 COPY spack.sh /etc/profile.d/z10_spack.sh

--- a/docker/spack-base/Dockerfile
+++ b/docker/spack-base/Dockerfile
@@ -19,7 +19,9 @@ RUN yum install -y autoconf automake cmake gcc gcc-c++ gcc-gfortran git make \
 RUN mkdir $SPACK_ROOT && \
     curl -s -L \
     https://api.github.com/repos/epfl-scitas/spack/tarball/releases/paien \
-    | tar xzC $SPACK_ROOT --strip 1
+    | tar xzC $SPACK_ROOT
+
+RUN ln -sfn $SPACK_ROOT/*/* $SPACK_ROOT/
 
 # Login script which enables spack (in a way that it runs after the lmod one)
 COPY spack.sh /etc/profile.d/z10_spack.sh

--- a/docker/spack-base/Dockerfile
+++ b/docker/spack-base/Dockerfile
@@ -21,6 +21,7 @@ RUN mkdir $SPACK_ROOT && \
     https://api.github.com/repos/epfl-scitas/spack/tarball/releases/paien \
     | tar xzC $SPACK_ROOT
 
+# Link from the subdirectory that contains the hash in the name
 RUN ln -sfnv $SPACK_ROOT/*/* $SPACK_ROOT/
 
 # Login script which enables spack (in a way that it runs after the lmod one)

--- a/docker/spack-base/Dockerfile
+++ b/docker/spack-base/Dockerfile
@@ -8,7 +8,7 @@ ENV SPACK_ROOT=/opt/spack \
 RUN yum upgrade -y && \
     yum clean all && rm -rf /var/cache/yum
 
-# Install the EPEL repository to have LMOD, and install other tools spack needs
+# Install the EPEL repository to have Lmod, and install other tools spack needs
 RUN yum install -y epel-release && \
     yum clean all && rm -rf /var/cache/yum
 RUN yum install -y autoconf automake cmake gcc gcc-c++ gcc-gfortran git make \

--- a/docker/spack-base/feature_tags
+++ b/docker/spack-base/feature_tags
@@ -1,0 +1,2 @@
+# This file contains a list of feature branches followed by
+# an optional (space separated) list of tags to also set.

--- a/docker/spack-base/hooks/post_push
+++ b/docker/spack-base/hooks/post_push
@@ -14,8 +14,8 @@ FEATURE_FILE='feature_tags'
 
 function add_tag() {
     echo "[INFO] Adding tag ${1}"
-    # docker tag $IMAGE_NAME $DOCKER_REPO:$1
-    # docker push $DOCKER_REPO:$1
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
 }
 
 function get_extra_tags() {

--- a/docker/spack-base/hooks/post_push
+++ b/docker/spack-base/hooks/post_push
@@ -1,23 +1,27 @@
 #!/bin/bash
 
 # Available variables:
-# SOURCE_BRANCH: the name of the branch or the tag that is currently being tested.
+# SOURCE_BRANCH: the name of the branch or the tag that is currently
+#                being tested.
 # SOURCE_COMMIT: the SHA1 hash of the commit being tested.
 # COMMIT_MSG: the message from the commit being tested and built.
 # DOCKER_REPO: the name of the Docker repository being built.
 # DOCKERFILE_PATH: the dockerfile currently being built.
 # CACHE_TAG: the Docker repository tag being built.
-# IMAGE_NAME: the name and tag of the Docker repository being built. (This variable is a combination of DOCKER_REPO:CACHE_TAG.)
+# IMAGE_NAME: the name and tag of the Docker repository being built.
+#             (This variable is a combination of DOCKER_REPO:CACHE_TAG.)
 
 RELEASE_FILE='release_tags'
 FEATURE_FILE='feature_tags'
 
+# Creates and publishes a tag for the just built image
 function add_tag() {
     echo "[INFO] Adding tag ${1}"
     docker tag $IMAGE_NAME $DOCKER_REPO:$1
     docker push $DOCKER_REPO:$1
 }
 
+# Retrieve a list of extra tags for a specific key from a file
 function get_extra_tags() {
     # $1 key
     # $2 filename

--- a/docker/spack-base/hooks/post_push
+++ b/docker/spack-base/hooks/post_push
@@ -50,4 +50,8 @@ elif [[ $SOURCE_BRANCH =~ feature/[a-z]* ]]; then
     add_tag ${featureName}-$(date '+%Y.%m.%d')
 fi
 
+if [ ${#CACHE_TAG} -gt 0 ]; then
+    add_tag ${CACHE_TAG}
+fi
+
 exit 0

--- a/docker/spack-base/hooks/post_push
+++ b/docker/spack-base/hooks/post_push
@@ -50,8 +50,4 @@ elif [[ $SOURCE_BRANCH =~ feature/[a-z]* ]]; then
     add_tag ${featureName}-$(date '+%Y.%m.%d')
 fi
 
-if [ ${#CACHE_TAG} -gt 0 ]; then
-    add_tag ${CACHE_TAG}
-fi
-
 exit 0

--- a/docker/spack-base/hooks/post_push
+++ b/docker/spack-base/hooks/post_push
@@ -50,6 +50,4 @@ elif [[ $SOURCE_BRANCH =~ feature/[a-z]* ]]; then
     add_tag ${featureName}-$(date '+%Y.%m.%d')
 fi
 
-
-
 exit 0

--- a/docker/spack-base/hooks/post_push
+++ b/docker/spack-base/hooks/post_push
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Available variables:
+# SOURCE_BRANCH: the name of the branch or the tag that is currently being tested.
+# SOURCE_COMMIT: the SHA1 hash of the commit being tested.
+# COMMIT_MSG: the message from the commit being tested and built.
+# DOCKER_REPO: the name of the Docker repository being built.
+# DOCKERFILE_PATH: the dockerfile currently being built.
+# CACHE_TAG: the Docker repository tag being built.
+# IMAGE_NAME: the name and tag of the Docker repository being built. (This variable is a combination of DOCKER_REPO:CACHE_TAG.)
+
+RELEASE_FILE='release_tags'
+FEATURE_FILE='feature_tags'
+
+function add_tag() {
+    echo "[INFO] Adding tag ${1}"
+    # docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    # docker push $DOCKER_REPO:$1
+}
+
+function get_extra_tags() {
+    # $1 key
+    # $2 filename
+    if [ -e ${2} -a ${#1} -gt 0 ]; then
+        if grep -q -s -P "^${1}" ${2}; then
+            # key was found in file
+            line=$(grep -P "^${1}" ${2})
+            echo ${line#${1}}
+        fi
+    fi
+}
+
+set -e
+
+# Starts here
+if [[ $SOURCE_BRANCH =~ releases/[a-z]* ]]; then
+    releaseName=$(echo $SOURCE_BRANCH | cut -d '/' -f 2)
+    echo "[INFO] this is a release branch: ${releaseName}"
+    releaseTags=$(get_extra_tags ${releaseName} ${RELEASE_FILE})
+    for tag in ${releaseTags}; do
+        add_tag ${tag}
+    done
+elif [[ $SOURCE_BRANCH =~ feature/[a-z]* ]]; then
+    featureName=$(echo $SOURCE_BRANCH | cut -d '/' -f 2)
+    echo "[INFO] this is a feature branch: ${featureName}"
+    featureTags=$(get_extra_tags ${featureName} ${FEATURE_FILE})
+    for tag in ${featureTags}; do
+        add_tag ${tag}
+    done
+    add_tag ${featureName}-$(date '+%Y.%m.%d')
+fi
+
+
+
+exit 0

--- a/docker/spack-base/release_tags
+++ b/docker/spack-base/release_tags
@@ -1,0 +1,4 @@
+# This file contains a list of releases followed by an optional
+# (space separated) list of tags to also set.
+cornalin 2017.07
+paien    2018.07

--- a/docker/spack-base/spack.sh
+++ b/docker/spack-base/spack.sh
@@ -1,0 +1,5 @@
+source $SPACK_ROOT/share/spack/setup-env.sh
+
+if [ -d $SPACK_ROOT/share/spack/lmod/ ]; then
+    module use $SPACK_ROOT/share/spack/lmod/
+fi


### PR DESCRIPTION
* will automatically build a container built on top of centos7
* extra hooks publish tags defined in `release_tags` for `release/*` branches and `feature_tags` for `feature/*` branches
* running with `docker run -it epflscitas/spack-base:<tag>` will drop user into a shell with a usable spack