### PR TITLE
Speed-up PR builds by using binary caches (SL-579)

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -122,6 +122,7 @@ modules:
       'gtkplus',
       'harfbuzz',
       'help2man',
+      'hpccg',
       'i7z',
       'inputproto',
       'jasper',

--- a/paien.yaml
+++ b/paien.yaml
@@ -136,7 +136,7 @@ packages:
       - py-sympy
       - py-ply
       - py-virtualenv
-      - py-click
+      # TODO: restore this spec- py-click
 
   # Python packages that requires LAPACK
   python_lapack_openmp:
@@ -286,6 +286,7 @@ packages:
       - fftw@3.3.7+mpi+openmp+fma simd=sse2,avx,avx2,avx512
       - hdf5@1.10.1+szip+mpi+hl+fortran+cxx
       - scotch@6.0.4+esmumps+mpi~metis
+      - hpccg
 # TODO: update scorep as described in issue SL-557
 #       - scorep@3.0
       - parmetis@4.0.3 ^metis@5.1.0+real64

--- a/paien.yaml
+++ b/paien.yaml
@@ -286,7 +286,7 @@ packages:
       - fftw@3.3.7+mpi+openmp+fma simd=sse2,avx,avx2,avx512
       - hdf5@1.10.1+szip+mpi+hl+fortran+cxx
       - scotch@6.0.4+esmumps+mpi~metis
-      - hpccg
+      - hpccg+mpi
 # TODO: update scorep as described in issue SL-557
 #       - scorep@3.0
       - parmetis@4.0.3 ^metis@5.1.0+real64

--- a/paien.yaml
+++ b/paien.yaml
@@ -136,6 +136,7 @@ packages:
       - py-sympy
       - py-ply
       - py-virtualenv
+      - py-click
 
   # Python packages that requires LAPACK
   python_lapack_openmp:

--- a/scripts/setup_pr_configuration.sh
+++ b/scripts/setup_pr_configuration.sh
@@ -102,8 +102,15 @@ do
 
     done < to_be_installed.${target}.txt
 done
+
+# Spack at the moment requires the directory `build_cache` to be present
+# in every mirror (otherwise this will result in a failure).
+mkdir -p ${SPACK_MIRROR_DIR}/build_cache
 spack mirror add --scope=site temp_mirror ${SPACK_MIRROR_DIR}
 
 # Add the central repository. This is needed for licensed software that has
 # to be built from sources and must be downloaded manually.
 spack mirror add --scope=site central_mirror /ssoft/spack/mirror
+
+# Add the binary mirror to speed-up PRs
+spack mirror add --scope=site binary_mirror  /ssoft/spack/paien/binary-mirror.v2/

--- a/scripts/test_pr_build.sh
+++ b/scripts/test_pr_build.sh
@@ -25,7 +25,7 @@ then
     echo "[${SPACK_TARGET_TYPE}] Nothing to install"
     cp resources/success.xml spec.${SPACK_TARGET_TYPE}.xml
 else
-    spack install --log-file=spec.${SPACK_TARGET_TYPE}.xml --log-format=junit ${specs_to_be_installed}
+    spack install --use-cache --log-file=spec.${SPACK_TARGET_TYPE}.xml --log-format=junit ${specs_to_be_installed}
 fi
 
 # Activate python extensions


### PR DESCRIPTION
This PR adds a pre-built binary mirror to the list of mirrors used for PRs, and uses the `--use-cache` option of `spack install`.  `py-click` is installed to try to leverage the new mechanism.