### PR TITLE
Spack uses ccache during PR builds.

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -72,6 +72,7 @@ modules:
       'cudnn',
       'curl%gcc@4.8.5',
       'fdtd',
+      'fio',
       'gaussian',
       'gcc',
       'git',

--- a/paien.yaml
+++ b/paien.yaml
@@ -77,6 +77,7 @@ packages:
       - automake@1.16.1
       - cmake@3.11.1
       - curl@7.59.0
+      - fio@2.19
       - git@2.17.0
       # - gnuplot@5.2.2 +X+pbm+wx ^pango+X
       - i7z@epfl-scitas

--- a/scripts/setup_pr_configuration.sh
+++ b/scripts/setup_pr_configuration.sh
@@ -34,6 +34,12 @@ cd ${SPACK_CHECKOUT_DIR}/etc/spack/
 ln -s /ssoft/spack/paien/spack.v2/etc/spack/compilers.yaml compilers.yaml
 # Remove config.yaml, as it point to install things directly in production
 rm config.yaml
+# Activate ccache for the PR
+cat > ${SPACK_CHECKOUT_DIR}/etc/spack/config.yaml <<EOF
+config:
+  ccache: true
+EOF
+
 cd -
 
 # Create a virtual env for the command just checked out

--- a/scripts/test_pr_build.sh
+++ b/scripts/test_pr_build.sh
@@ -6,7 +6,7 @@
 #
 
 # Configure ccache properly. Caches are kept separated among different targets.
-ccache_config_dir="~/.ccache/${SPACK_TARGET_TYPE}"
+ccache_config_dir="${HOME}/.ccache/${SPACK_TARGET_TYPE}"
 ccache_cache_dir="/scratch/scitasbuild/ccache/${SPACK_TARGET_TYPE}"
 
 mkdir -p ${ccache_config_dir}

--- a/scripts/test_pr_build.sh
+++ b/scripts/test_pr_build.sh
@@ -6,14 +6,17 @@
 #
 
 # Configure ccache properly. Caches are kept separated among different targets.
-mkdir -p ~/.ccache/${SPACK_TARGET_TYPE}
-mkdir -p /scratch/scitasbuild/ccache/${SPACK_TARGET_TYPE}
+ccache_config_dir="~/.ccache/${SPACK_TARGET_TYPE}"
+ccache_cache_dir="/scratch/scitasbuild/ccache/${SPACK_TARGET_TYPE}"
 
-export CCACHE_CONFIGPATH=~/.ccache/${SPACK_TARGET_TYPE}/ccache.conf
+mkdir -p ${ccache_config_dir}
+mkdir -p ${ccache_cache_dir}
+
+export CCACHE_CONFIGPATH=${ccache_config_dir}/ccache.conf
 
 cat > ${CCACHE_CONFIGPATH} <<EOF
 max_size = 100.0G
-cache_dir = /scratch/scitasbuild/ccache/${SPACK_TARGET_TYPE}
+cache_dir = ${ccache_cache_dir}
 EOF
 
 # Zero-out statistics

--- a/scripts/test_pr_build.sh
+++ b/scripts/test_pr_build.sh
@@ -17,6 +17,7 @@ export CCACHE_CONFIGPATH=${ccache_config_dir}/ccache.conf
 cat > ${CCACHE_CONFIGPATH} <<EOF
 max_size = 100.0G
 cache_dir = ${ccache_cache_dir}
+temporary_dir = /tmp/ccache/${SPACK_TARGET_TYPE}
 EOF
 
 # Print configuration
@@ -35,8 +36,11 @@ SPACK_CHECKOUT_DIR=$(cat spack_dir.txt)
 # in the temporary workspace
 spack install intel@18.0.2 %gcc@4.8.5
 . ${SPACK_CHECKOUT_DIR}/share/spack/setup-env.sh
+
+# Print out information that could be useful for logging and debugging
 which spack
 spack mirror list
+spack config get config
 
 specs_to_be_installed=$(cat to_be_installed.${SPACK_TARGET_TYPE}.txt)
 

--- a/scripts/test_pr_build.sh
+++ b/scripts/test_pr_build.sh
@@ -5,6 +5,20 @@
 # SPACK_PRODUCTION_DIR: path where the production instance of Spack resides
 #
 
+# Configure ccache properly. Caches are kept separated among different targets.
+mkdir -p ~/.ccache/${SPACK_TARGET_TYPE}
+mkdir -p /scratch/scitasbuild/ccache/${SPACK_TARGET_TYPE}
+
+export CCACHE_CONFIGPATH=~/.ccache/${SPACK_TARGET_TYPE}/ccache.conf
+
+cat > ${CCACHE_CONFIGPATH} <<EOF
+max_size = 100.0G
+cache_dir = /scratch/scitasbuild/ccache/${SPACK_TARGET_TYPE}
+EOF
+
+# Zero-out statistics
+ccache -z
+
 # Retrieve which Spack instance we need to use for the build
 SPACK_CHECKOUT_DIR=$(cat spack_dir.txt)
 
@@ -27,6 +41,9 @@ then
 else
     spack install --log-file=spec.${SPACK_TARGET_TYPE}.xml --log-format=junit ${specs_to_be_installed}
 fi
+
+# Show ccache statistics
+ccache -s
 
 # Activate python extensions
 

--- a/scripts/test_pr_build.sh
+++ b/scripts/test_pr_build.sh
@@ -19,6 +19,9 @@ max_size = 100.0G
 cache_dir = ${ccache_cache_dir}
 EOF
 
+# Print configuration
+ccache -p
+
 # Zero-out statistics
 ccache -z
 


### PR DESCRIPTION
Caches are stored in different folders depending on the architecture. This should ensure that the statistics of the various workers are kept separated and not intertwined.