### PR TITLE
py-pytorch: specify versions and dependencies consistently

### DIFF
--- a/paien.yaml
+++ b/paien.yaml
@@ -180,7 +180,7 @@ packages:
       - python
       - lapack
     specs:
-      - py-pytorch~cuda@0.3.1 ^py-numpy+blas+lapack@1.14.3
+      - py-pytorch@0.3.1~cuda ^py-numpy+blas+lapack@1.14.3
       - py-htseq@0.10.0 ^py-matplotlib@2.0.0 ^py-numpy+blas+lapack@1.14.3
 
   gnu_python_2_only_lapack_openmp:

--- a/paien.yaml
+++ b/paien.yaml
@@ -177,7 +177,7 @@ packages:
       - python
       - lapack
     specs:
-      - py-pytorch ~cuda ^py-numpy +blas +lapack@1.14.3
+      - py-pytorch~cuda@0.3.1 ^py-numpy+blas+lapack@1.14.3
       - py-htseq@0.10.0 ^py-matplotlib@2.0.0 ^py-numpy+blas+lapack@1.14.3
 
   gnu_python_2_only_lapack_openmp:
@@ -587,8 +587,11 @@ packages:
       - compiler
       - lapack
     specs:
-      - magma+fortran ^cuda@9.1.85
-      - py-pytorch +cuda +cudnn ~nccl +magma ^py-numpy +blas +lapack ^magma +fortran +shared ^cuda@9.1.85
+      - magma@2.3.0+fortran+shared ^cuda@9.1.85
+      - py-pytorch@0.3.1+cuda+cudnn~nccl+magma
+        ^py-numpy+blas+lapack@1.14.3
+        ^magma@2.3.0+fortran+shared
+        ^cuda@9.1.85
 
 #   gnu-gpu-mpi-applications:
 #     target_matrix:


### PR DESCRIPTION
This shouldn't reinstall anything, it simply reflects the current state better.

* py-pytorch and magma versions were not specified
* magma variants in py-pytorch spec were not consistent with magma spec