### PR TITLE
Revert "py-xarray has been updated to 0.11.0"

### DIFF
--- a/paien.yaml
+++ b/paien.yaml
@@ -163,7 +163,7 @@ packages:
       - py-scikit-learn@0.19.1 ^py-scipy@1.1.0 ^py-numpy+blas+lapack@1.14.3
       - py-theano@1.0.2~gpu ^py-scipy@1.1.0 ^py-numpy+blas+lapack@1.14.3
       - py-pandas@0.23.4 ^py-numpy+blas+lapack@1.14.3
-      - py-xarray@0.11.0 ^py-pandas@0.23.4 ^py-numpy+blas+lapack@1.14.3
+      - py-xarray@0.9.1 ^py-pandas@0.23.4 ^py-numpy+blas+lapack@1.14.3
 
   gnu-python_lapack_openmp:
     target_matrix:


### PR DESCRIPTION
Reverts epfl-scitas/spack-packagelist#126

Turns out that on our configuration py-xarray is affected by https://github.com/pydata/xarray/issues/1761. Restoring the old version of the package.