### PR TITLE
Adding fastqc to core and whitelisting it

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -71,6 +71,7 @@ modules:
       'cuda',
       'cudnn',
       'curl%gcc@4.8.5',
+      'fastqc%gcc@4.8.5',
       'fdtd',
       'fio',
       'gaussian',

--- a/paien.yaml
+++ b/paien.yaml
@@ -77,6 +77,7 @@ packages:
       - automake@1.16.1
       - cmake@3.11.1
       - curl@7.59.0
+      - fastqc@0.11.8
       - fio@2.19
       - git@2.17.0
       - git-lfs@2.3.0^git@2.17.0


### PR DESCRIPTION
* fastqc depend on perl and jdk and both are already installed on core
* SL-481