### PR TITLE
openbabel: 2.4.1

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -98,6 +98,7 @@ modules:
       'molpro',
       'mvapich2',
       'openblas',
+      'openbabel',
       'openmpi',
       'parallel%gcc@4.8.5',
       'picard',

--- a/humagne.yaml
+++ b/humagne.yaml
@@ -259,6 +259,30 @@ packages:
       - py-bioepic ^jellyfish ^py-scipy@1.2.1 ^py-numpy+blas+lapack@1.16.3
       - sicer ^py-numpy+blas+lapack@1.16.3
 
+  # Python 3 only packages
+  gnu_python_3:
+    target_matrix:
+      - gnu-stable
+    target_filter:
+      python: ['python@3.7.3+optimizations+tkinter']
+    requires:
+      - architecture
+      - compiler
+      - python
+    specs:
+      - openbabel@2.4.1
+  intel_python_3:
+    target_matrix:
+      - intel-stable
+    target_filter:
+      python: ['python@3.7.3+optimizations+tkinter']
+    requires:
+      - architecture
+      - compiler
+      - python
+    specs:
+      - openbabel@2.4.1 ^freetype@2.7.1
+
   # Code compiled with all the stacks that does not require
   # MPI or LAPACK
   serial:

--- a/humagne.yaml
+++ b/humagne.yaml
@@ -270,7 +270,7 @@ packages:
       - compiler
       - python
     specs:
-      - openbabel@2.4.1
+      - openbabel@2.4.1+python
   intel_python_3:
     target_matrix:
       - intel-stable
@@ -281,7 +281,7 @@ packages:
       - compiler
       - python
     specs:
-      - openbabel@2.4.1 ^freetype@2.7.1
+      - openbabel@2.4.1+python ^freetype@2.7.1
 
   # Code compiled with all the stacks that does not require
   # MPI or LAPACK


### PR DESCRIPTION
* installing on python3 only (as it extends python and we can only do it for one)
* different groups for intel and gnu as the latest freetype does not build on intel