### PR TITLE
--not-installed to --implicit

### DIFF
--- a/jenkins/deploy/scripts/install_production_compilers.sh
+++ b/jenkins/deploy/scripts/install_production_compilers.sh
@@ -21,7 +21,7 @@ spack --version
 spack compiler add --scope=site
 
 # Register Spack bootstrapped compilers
-to_be_installed=$(spack filter --not-installed $(cat compilers.${SPACK_TARGET_TYPE}.txt))
+to_be_installed=$(spack filter --implicit $(cat compilers.${SPACK_TARGET_TYPE}.txt))
 
 if [[ -z "${to_be_installed}" ]]
 then

--- a/jenkins/deploy/scripts/install_production_stack.sh
+++ b/jenkins/deploy/scripts/install_production_stack.sh
@@ -20,7 +20,7 @@ deactivate
 spack --version
 
 # Register Spack bootstrapped compilers
-TO_BE_INSTALLED=$(spack filter --not-installed $(cat stack.${SPACK_TARGET_TYPE}.txt))
+TO_BE_INSTALLED=$(spack filter --implicit $(cat stack.${SPACK_TARGET_TYPE}.txt))
 
 if [[ -n "$TO_BE_INSTALLED" ]]
 then

--- a/jenkins/deploy/scripts/populate_mirror.sh
+++ b/jenkins/deploy/scripts/populate_mirror.sh
@@ -22,7 +22,7 @@ do
 
     echo "[${target}] Selecting the ones still to be installed"
     # TODO: if concretization is slow this command could output also the yaml file
-    SPACK_TARGET_TYPE="${target}" spack filter --not-installed $(cat all_specs.${target}.txt) > to_be_installed.${target}.txt
+    SPACK_TARGET_TYPE="${target}" spack filter --implicit $(cat all_specs.${target}.txt) > to_be_installed.${target}.txt
     # TODO: stash concretized file to reduce deployment time later
     #echo "[${target}] Writing concretized yaml file"
     #spack spec -y $(cat to_be_installed.${target}.txt) > specs.${target}.yaml

--- a/jenkins/pr/scripts/setup_pr_configuration.sh
+++ b/jenkins/pr/scripts/setup_pr_configuration.sh
@@ -82,7 +82,7 @@ do
     # FIXME: so we need to force SPACK_TARGET_TYPE to be the target we are
     # FIXME: querying if we don't want false positives with mixed targets in
     # FIXME: concretized the spec
-    SPACK_TARGET_TYPE="${target}" spack filter --not-installed --output to_be_installed.${target}.txt $(cat all_specs.${target}.txt)
+    SPACK_TARGET_TYPE="${target}" spack filter --implicit --output to_be_installed.${target}.txt $(cat all_specs.${target}.txt)
     if [ $? -ne 0 ]
     then
         echo "[${target}] ERROR while computing list of packages!"


### PR DESCRIPTION
For to add as explicit implicitly installed softwares

```
$ spack filter --help
...
  --not-installed  select specs that are not yet installed
  --explicit       select specs that were installed explicitly
  --implicit       select specs that are not installed or were installed implicitly
```