### PR TITLE
Added the new version of Molpro to the gnu stack

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -337,9 +337,6 @@ modules:
           - PLUMED_ROOT
     molpro:
       template: 'modules/group_restricted.lua'
-      environment:
-        prepend_path:
-          'PATH': '${PREFIX}/molprop_2015_1_linux_x86_64_i8/bin'
 
     opencv:
       environment:

--- a/configuration/packages.yaml
+++ b/configuration/packages.yaml
@@ -139,6 +139,11 @@ packages:
   guile:
     variants: '~threads'
 
+  molpro:
+    permissions:
+      read: group
+      group: molpro-soft
+
   vasp:
     permissions:
       read: group

--- a/humagne.yaml
+++ b/humagne.yaml
@@ -553,6 +553,7 @@ packages:
       - cp2k+mpi+plumed
         ^fftw+mpi~openmp+fma simd=sse2,avx,avx2,avx512
         ^plumed+mpi+gsl
+      - molpro@2015.1+mpi
       - molpro@2019.2+mpi
       - nwchem@6.8 ^netlib-scalapack@2.0.2 ^python@2.7.16+tkinter
       - vasp@5.4.4 ^fftw~mpi~openmp+fma simd=sse2,avx,avx2,avx512

--- a/humagne.yaml
+++ b/humagne.yaml
@@ -553,7 +553,7 @@ packages:
       - cp2k+mpi+plumed
         ^fftw+mpi~openmp+fma simd=sse2,avx,avx2,avx512
         ^plumed+mpi+gsl
-      - molpro@2015.1+mpi
+      - molpro@2019.2+mpi
       - nwchem@6.8 ^netlib-scalapack@2.0.2 ^python@2.7.16+tkinter
       - vasp@5.4.4 ^fftw~mpi~openmp+fma simd=sse2,avx,avx2,avx512
       # TODO: - caffe@1.0+python+opencv  ^hdf5+szip+mpi~cxx ^opencv@3.2.0+qt~vtk~eigen ^qt@4.8.6 ^py-numpy+blas+lapack@1.12.1 ^boost@1.63.0+icu+mpi+python ^python@2.7.13


### PR DESCRIPTION
The lines removed from the configuration/modules.yaml are now managed automatically by the spack recipe (the exact path varies significantly between versions)