### PR TITLE
Adding GLPK with gcc

### DIFF
--- a/configuration/modules.yaml
+++ b/configuration/modules.yaml
@@ -81,6 +81,7 @@ modules:
       'gcc@8.3.0',
       'gcc@7.4.0',
       'git',
+      'glpk',
       'gnuplot',
       'gromacs',
       'gurobi',

--- a/humagne.yaml
+++ b/humagne.yaml
@@ -298,7 +298,6 @@ packages:
       - 'fftw@3.3.8~mpi~openmp+fma simd=sse2,avx,avx2,avx512'
       - 'fftw@3.3.8~mpi+openmp+fma simd=sse2,avx,avx2,avx512'
       - nfft@3.4.1 ^fftw@3.3.8~mpi~openmp+fma simd=sse2,avx,avx2,avx512
-      # FIXME: intel gives an internal compiler error - glpk@4.65+gmp
       - gsl
       - hdf5+szip~mpi+hl+fortran+cxx
       - metis@5.1.0+real64 ^guile~threads
@@ -330,6 +329,7 @@ packages:
       - compiler
     specs:
       - libgd
+      - glpk@4.65+gmp
 
   # Serial code that uses LAPACK
   lapack:


### PR DESCRIPTION
* intel gives an internal compiler error
* https://www.gnu.org/software/glpk/
* dependency of R package Rglpk (INC0347015)