### PR TITLE
senv.py: set the compiler for the package and not for a dependency

### DIFF
--- a/configuration/packages.yaml
+++ b/configuration/packages.yaml
@@ -143,9 +143,6 @@ packages:
       read: group
       group: crystal-soft
 
-  fftw:
-    variants: '+fma+mpi+openmp simd=avx,avx2,avx512,sse2'
-
   guile:
     variants: '~threads'
 

--- a/configuration/packages.yaml
+++ b/configuration/packages.yaml
@@ -143,6 +143,9 @@ packages:
       read: group
       group: crystal-soft
 
+  fftw:
+    variants: '+fma+mpi+openmp simd=avx,avx2,avx512,sse2'
+
   guile:
     variants: '~threads'
 

--- a/humagne.yaml
+++ b/humagne.yaml
@@ -343,7 +343,7 @@ packages:
       - architecture
       - compiler
     specs:
-      - qt@5.11.3 +opengl+webkit ^python@3.7.3+optimizations+tkinter ^guile~threads ^freetype@2.7.1 ^harfbuzz@2.2.0
+      - qt@5.11.3 +opengl+webkit ^python@3.7.3+optimizations+tkinter ^guile~threads ^freetype@2.7.1 ^harfbuzz@2.2.0 ^mesa~llvm
 
   # Serial code that uses LAPACK
   lapack:

--- a/humagne.yaml
+++ b/humagne.yaml
@@ -313,7 +313,6 @@ packages:
       - bedtools2@2.27.1
       - intel-tbb ^guile~threads
       - eigen~fftw~suitesparse~metis~scotch~mpfr ^guile~threads
-      - qt@5.11.3 +opengl+webkit ^python@3.7.3+optimizations+tkinter ^guile~threads
       - star
       # FIXME: gdl (intel internal compiler error on plplot) SL-577, see gnu-serial
       - chip-seq
@@ -335,6 +334,16 @@ packages:
     specs:
       - libgd
       - glpk@4.65+gmp
+      - qt@5.11.3 +opengl+webkit ^python@3.7.3+optimizations+tkinter ^guile~threads
+
+  serial_intel:
+    target_matrix:
+      - intel-stable
+    requires:
+      - architecture
+      - compiler
+    specs:
+      - qt@5.11.3 +opengl+webkit ^python@3.7.3+optimizations+tkinter ^guile~threads ^freetype@2.7.1 ^harfbuzz@2.2.0
 
   # Serial code that uses LAPACK
   lapack:

--- a/senv.py
+++ b/senv.py
@@ -213,4 +213,12 @@ def packages(ctx, target, output, only):
     penv = ProductionEnvironment(ctx.parent.configuration, only=only)
 
     for item in filter(lambda x: x.architecture == target, penv.items()):
-        output.write(item.spec + ' %' + item.compiler + ' target=' + item.architecture + '\n')
+        if '^' in item.spec:
+            # insert compiler before dependencies
+            dep_pos = item.spec.find('^')
+            patched_spec = item.spec[:dep_pos] \
+                + ' %' + item.compiler + ' ' \
+                + item.spec[dep_pos:]
+        else:
+            patched_spec = item.spec + ' %' + item.compiler
+        output.write(patched_spec + ' target=' + item.architecture + '\n')


### PR DESCRIPTION
In the list of specs insert the compiler immediately before the first dependency appears. In some cases, if the compiler appears at the end it will only be applied to the dependency and another compiler will be chosen for the package itself.

Helps solving the concretization issues that cause the failures in #189 .