### PR TITLE
fftw: define default variant

### DIFF
--- a/configuration/packages.yaml
+++ b/configuration/packages.yaml
@@ -143,6 +143,9 @@ packages:
       read: group
       group: crystal-soft
 
+  fftw:
+    variants: '+fma+mpi+openmp simd=avx,avx2,avx512,sse2'
+
   guile:
     variants: '~threads'
 


### PR DESCRIPTION
* to avoid having to explicitly having to specify the variant for each
  package that uses fftw

* should also help with cases like #189 where a new dependency is introduced but cannot be explicitly in the spec because the old package definition doesn't know about it.