### PR TITLE
Revert "Adding default variants and versions for python and py-numpy (#194)"

### DIFF
--- a/configuration/packages.yaml
+++ b/configuration/packages.yaml
@@ -149,19 +149,6 @@ packages:
   guile:
     variants: '~threads'
 
-  'python@3.7.3':
-    variants: '+optimizations+tkinter'
-
-  'python@2.7.16':
-    variants: '+tkinter'
-
-  python:
-    version: ['@3.7.3']
-
-  py-numpy:
-    variants: '+blas+lapack'
-    version: ['@0.16.3']
-
   molpro:
     permissions:
       read: group


### PR DESCRIPTION
This reverts commit c9b27ad4138f5f363f9704c1d0acd33346c9745f which we
found out later introduced some wrong syntax.