### PR TITLE
Adding paraview back

### DIFF
--- a/humagne.yaml
+++ b/humagne.yaml
@@ -613,11 +613,11 @@ packages:
       # TODO: port amber from cornalin
       #       - amber@16+mpi ^netcdf-fortran ^netcdf@4.4.1.1+mpi ^hdf5+szip+mpi~cxx ^py-scipy@0.19.0 ^py-matplotlib@2.2.3 ^py-numpy+blas+lapack@1.12.1 ^python@2.7.13
       # TODO: - gmsh@3.0.1+mpi+hdf5+fltk+compression ^hdf5+szip+mpi~cxx
-      # - paraview@5.5.2+mpi+osmesa~qt+python+hdf5
-      #   ^py-matplotlib@2.2.3
-      #   ^py-numpy+blas+lapack@1.16.3
-      #   ^python@3.7.3+optimizations+tkinter
-      #   ^hdf5+szip+mpi+hl+fortran+cxx
+      - paraview@5.5.2+mpi+osmesa~qt+python+hdf5
+        ^py-matplotlib@2.2.3
+        ^py-numpy+blas+lapack@1.16.3
+        ^python@3.7.3+optimizations+tkinter
+        ^hdf5+szip+mpi+hl+fortran+cxx
       # FIXME: - simpson@master ^gsl@2.1 ^nfft@3.3.2 ^fftw@3.3.4 ^tk@8.6.3 ^tcl@8.6.5
 
   mpi-lapack-applications:


### PR DESCRIPTION
Paraview was installed before the change on numpy. 
It was removed du to its dependency to py-numpy but was not reinstalled automatically
I guess it was installed as a dependency since it was commented in the list of packages.