### PR TITLE
Change package sox to gcc_serial_packages

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -62,7 +62,6 @@
   # - nfft
   #   ^fftw ~mpi~openmp
   - scotch+esmumps~metis~mpi
-  - sox
   - stacks
   - star
   - subread
@@ -103,6 +102,7 @@
     ^openssl@1.1.1b
   - openblas threads=openmp
   - python@{{ environment.python.3 }}+tkinter~optimizations+debug
+  - sox
   - xgboost {{ cuda_variant(environment, dep=True) }}
 
 - intel_serial_packages:


### PR DESCRIPTION
This package failed to compile with intel. It will now be compiled using gcc.