### PR TITLE
pybigwig: add new package to arvine (INC0459082)

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -144,6 +144,7 @@
   - py-deeptools
   - py-macs2
   - py-pybind11
+  - py-pybigwig
   - py-scikit-learn
   - py-statsmodels
   - py-theano {{ cuda_variant(environment, dep=True) }}


### PR DESCRIPTION
This package was already installed as a dependency from deeptools,
but now we are declaring explicitly so that a module can be built.