### PR TITLE
Remove nvhpc section redefinining compiler variables

### DIFF
--- a/templates/scitas/modules_lmod_specific.yaml.j2
+++ b/templates/scitas/modules_lmod_specific.yaml.j2
@@ -33,17 +33,6 @@
 '^cuda':
   autoload: direct
 
-nvhpc:
-  environment:
-    set:
-      CC:  nvc
-      CXX: nc++
-      F77: nvfortran
-      FC:  nvfortran
-      F90: nvfortran
-      SLURM_MPI_TYPE: pmix
-      OMPI_MCA_btl_openib_warn_default_gid_prefix: '0'
-
 ################
 # MPI
 ################


### PR DESCRIPTION
Removed nvhpc section that was re-defining the compiler variables. There was a typo for `CXX` which was set to `nc++` instead of `nvc++`.