### PR TITLE
nvhpc is not a "compiler" in arvine so it needs a separate configuration

### DIFF
--- a/templates/scitas/modules_lmod_specific.yaml.j2
+++ b/templates/scitas/modules_lmod_specific.yaml.j2
@@ -33,6 +33,12 @@
 '^cuda':
   autoload: direct
 
+nvhpc:
+  environment:
+    set:
+      SLURM_MPI_TYPE: pmix
+      OMPI_MCA_btl_openib_warn_default_gid_prefix: '0'
+
 ################
 # MPI
 ################


### PR DESCRIPTION
Revert partially a wrong modification for nvhpc