### PR TITLE
jasper: whitelist package

### DIFF
--- a/templates/scitas/modules_whitelist.yaml.j2
+++ b/templates/scitas/modules_whitelist.yaml.j2
@@ -10,3 +10,4 @@
 {% endif %}
 - petsc
 - openblas
+- jasper


### PR DESCRIPTION
Spack was not creating the module for jasper. For this reason we have added this package to whitelist.