### PR TITLE
ffmpeg: add h264 encoding support

### DIFF
--- a/templates/common/modules_suffixes.yaml.j2
+++ b/templates/common/modules_suffixes.yaml.j2
@@ -13,3 +13,4 @@ file_systems=nfs: nfs
 device=ch3: ch3
 device=ch4: ch4
 +debug: dbg
++libx264: x264

--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -43,7 +43,9 @@
   - eigen
   - fastqc
   - ffmpeg
+  - ffmpeg +libx264
   - fftw ~mpi+openmp
+  - freefem
   # - freebayes
   - gsl
   - hdf5+szip~mpi+hl+fortran+cxx


### PR DESCRIPTION
This commit add a second package ffmpeg with support to h264 encoding.
The normal ffmpeg remains in the stack. A suffix was added for +libx264.