### PR TITLE
ffmpeg: add h264 encoding support

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -43,6 +43,7 @@
   - eigen
   - fastqc
   - ffmpeg
+  - ffmpeg +libx264
   - fftw ~mpi+openmp
   # - freebayes
   - gsl

--- a/templates/scitas/modules_lmod_specific.yaml.j2
+++ b/templates/scitas/modules_lmod_specific.yaml.j2
@@ -234,3 +234,7 @@ spark:
 
 vasp:
   template: 'modules/group_restricted.lua'
+
+ffmpeg:
+  suffixes:
+    '+libx264': h264


### PR DESCRIPTION
This commit add a second ffmpeg package with support to h264 encoding.
The old ffmpeg remains in the stack and a suffix is added for +libx264
to distinguish between both versions.