### PR TITLE
freefem: add package to arvine

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -488,6 +488,7 @@
   {% endif %}
   {% if not 'gpu' in environment %}
   - relion +mklfft ~cuda
+  - freefem +mpi +petsc ^/ohnennk
   {% endif %}
 {% endif %}
   - yambo+mpi io=iotk,etsf-io


### PR DESCRIPTION
Package added to `intel_mpi_packages`.

From `spack info freefem` we can see that blas is not a dependency:
```
Build Dependencies:
    mpi  slepc
Link Dependencies:
    mpi  slepc
```
An installation test was made for izar following the procedure described in the document below:
[freefem-install-test.pdf](https://github.com/epfl-scitas/spack-packagelist/files/8400174/freefem-install-test.pdf)