### PR TITLE
ffmpeg: move package to gcc

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -43,7 +43,6 @@
   - eigen
   - fastqc
   - ffmpeg
-  - ffmpeg +libx264
   - fftw ~mpi+openmp
   # - freebayes
   - gsl
@@ -88,6 +87,7 @@
 
 - gcc_serial_packages:
   - {{ environment.stable.intel.blas }}
+  - ffmpeg +libx264
   - glpk+gmp
   # julia >= 0..5 conflicts with intel compilers
   # it is not in the gcc_serial_packages_python due to the dependecy to mkl


### PR DESCRIPTION
Package is no longer compiled with intel compiler. An error was found during `libx264` compilation process.