### PR TITLE
fftw: add fftw compiled with gcc@9.3.0

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -608,3 +608,6 @@
 - intel_bleeding_edge_serial_packages:
 
 - nvhpc_bleeding_edge_serial_packages:
+
+- gcc_bleeding_edge_mpi_packages:
+  - fftw+mpi+openmp

--- a/templates/scitas/arvine/matrix.yaml.j2
+++ b/templates/scitas/arvine/matrix.yaml.j2
@@ -9,6 +9,10 @@
 - matrix:
   - [${{compiler}}_bleeding_edge_serial_packages]
   - [$%{{compiler}}_bleeding_edge_compiler]
+
+- matrix:
+  - [${{compiler}}_bleeding_edge_mpi_packages]
+  - [$%{{compiler}}_bleeding_edge_compiler]
     {% endif %}
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
Create the new tag gcc_bleeding_edge_mpi_packages where the
fftw package is added and update the related matrix file.