### PR TITLE
bugfix: add empty intel_bleeding_edge_mpi_packages

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -611,3 +611,5 @@
 
 - gcc_bleeding_edge_mpi_packages:
   - fftw+mpi+openmp
+
+- intel_bleeding_edge_mpi_packages:


### PR DESCRIPTION
The new spec matrix added with PR #229 was looking
for a missing definition `intel_bleeding_edge_mpi_packages`
which this commit now adds.