### PR TITLE
Packages/arvine/fftw gcc9.3.0

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -610,6 +610,6 @@
 - nvhpc_bleeding_edge_serial_packages:
 
 - gcc_bleeding_edge_mpi_packages:
-  - fftw+mpi+openmp
+  - fftw+mpi+openmp ^mvapich2
 
 - intel_bleeding_edge_mpi_packages:

--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -610,6 +610,6 @@
 - nvhpc_bleeding_edge_serial_packages:
 
 - gcc_bleeding_edge_mpi_packages:
-  - fftw+mpi+openmp ^mvapich2
+  - fftw+mpi+openmp
 
 - intel_bleeding_edge_mpi_packages:

--- a/templates/scitas/arvine/matrix.yaml.j2
+++ b/templates/scitas/arvine/matrix.yaml.j2
@@ -12,6 +12,7 @@
 
 - matrix:
   - [${{compiler}}_bleeding_edge_mpi_packages]
+  - [$^{{compiler}}_bleeding_edge_mpi]
   - [$%{{compiler}}_bleeding_edge_compiler]
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
This PR merges several commits in an attempt to integrate `fftw+mpi+openmp%gcc@9.3.0` in arvine.