### PR TITLE
mathematica: add new version 13.0

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -252,6 +252,7 @@
   - likwid@4.3.0
   - maple@2017
   - mathematica@11.1.1
+  - mathematica@13.0  
   - matlab@R2019b
   - smr@2017.06
   - totalview@2017.2.11


### PR DESCRIPTION
The spack-repo-externals repository has already been updated with the new version of mathematica:

    version('9.0.1')
    version('11.1.1')
    version('13.0')

