### PR TITLE
cudnn: add new version 8.4.1

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -79,6 +79,7 @@
   - cuda@11.0.2
   - cuda@11.1.1
   - cuda@11.2.2
+  - cuda@11.6.2
   - cudnn ^{{ environment.stable.cuda.package }} ^libiconv
   - cudnn@8.0.2.39-10.2-linux-x64 ^{{ environment.stable.cuda.package }} ^libiconv
   - cudnn@7.4.2.24-10.0-linux-x64 ^cuda@10.0.130

--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -87,7 +87,7 @@
   - cudnn@8.0.2.39-11.0-linux-x64 ^cuda@11.0.2 ^libiconv
   - cudnn@8.0.5.39-11.1-linux-x64 ^cuda@11.1.1
   - cudnn@8.1.1.33-11.2-linux-x64 ^cuda@11.2.2
-  - cudnn@8.4.1.50-11.6-linux-x64 ^cuda@11.2.2
+  - cudnn@8.4.1.50-11.6-linux-x64 ^cuda@11.6.2
   {% endif %}
 
 - gcc_serial_packages:

--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -86,6 +86,7 @@
   - cudnn@8.0.2.39-11.0-linux-x64 ^cuda@11.0.2 ^libiconv
   - cudnn@8.0.5.39-11.1-linux-x64 ^cuda@11.1.1
   - cudnn@8.1.1.33-11.2-linux-x64 ^cuda@11.2.2
+  - cudnn@8.4.1.50-11.6-linux-x64 ^cuda@11.2.2
   {% endif %}
 
 - gcc_serial_packages:


### PR DESCRIPTION
According the nVIDIA documentation, the version 8.4.1.50-11.6 is able to
run with any version of cuda 11.x

The following tests were made :

```
$ spack -C . spec -I cudnn@8.4.1.50-11.6-linux-x64 %gcc@8.4.0 target=skylake_avx512 ^cuda@11.2.2
    Input spec
    --------------------------------
     -   cudnn@8.4.1.50-11.6-linux-x64%gcc@8.4.0 arch=linux-None-skylake_avx512
     -       ^cuda@11.2.2
    
    Concretized
    --------------------------------
     -   cudnn@8.4.1.50-11.6-linux-x64%gcc@8.4.0 arch=linux-rhel7-skylake_avx512
    [+]      ^cuda@11.2.2%gcc@8.4.0 arch=linux-rhel7-skylake_avx512
    [^]          ^libxml2@2.9.10%gcc@8.4.0~python arch=linux-rhel7-skylake_avx512
    [^]              ^libiconv@1.16%gcc@8.4.0 arch=linux-rhel7-skylake_avx512
    [^]              ^pkgconf@1.7.3%gcc@8.4.0 arch=linux-rhel7-skylake_avx512
    [^]              ^xz@5.2.5%gcc@8.4.0 arch=linux-rhel7-skylake_avx512
    [^]              ^zlib@1.2.11%gcc@8.4.0+optimize+pic+shared arch=linux-rhel7-skylake_avx512

```

All the dependencies were correctly identified from upstream and the subsequent installation process went fine.

```
$ spack -C . install cudnn@8.4.1.50-11.6-linux-x64 %gcc@8.4.0 target=skylake_avx512 ^cuda@11.2.2                                                                           
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/libiconv-1.16-u3vsa4tix7d3qfmdahcuq35pejmjz4aq                                                                                   
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/libiconv-1.16-u3vsa4tix7d3qfmdahcuq35pejmjz4aq                                                                                   
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/pkgconf-1.7.3-fdjmfe7djjosne5e6jcvysb4d34juvn5                                                                                   
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/pkgconf-1.7.3-fdjmfe7djjosne5e6jcvysb4d34juvn5                                                                                   
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/xz-5.2.5-uam5lr5fa5iy7zo5xs2p6fwximpj7ozr                                                                                        
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/xz-5.2.5-uam5lr5fa5iy7zo5xs2p6fwximpj7ozr                                                                                        
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/zlib-1.2.11-dxffqppihry4d4n5lnbarbnvoanrsykc                                                                                     
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/zlib-1.2.11-dxffqppihry4d4n5lnbarbnvoanrsykc                                                                                     
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/libxml2-2.9.10-hmxz7ofkowvmgqutcvmrdm7bpp3osrpj                                                                                  
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/libxml2-2.9.10-hmxz7ofkowvmgqutcvmrdm7bpp3osrpj                                                                                  
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/cuda-11.2.2-ad3oa5gauz5yn67ymtn3kudej5nijpof                                                                                     
[+] /ssoft/spack/arvine/v1/opt/spack/linux-rhel7-skylake_avx512/gcc-8.4.0/cuda-11.2.2-ad3oa5gauz5yn67ymtn3kudej5nijpof                                                                                     
==> Installing cudnn                                                                                                                                                                                       
==> No binary for cudnn found: installing from source                                                                                                                                                      
==> cudnn: Executing phase: 'install'                                                                                                                                                                      [+] /work/scitas-ge/erothe/incs/cudnn/opt/linux-rhel7-skylake_avx512/gcc-8.4.0/cudnn-8.4.1.50-11.6-linux-x64-5she5sthp4ppupz4tc6fbwyny43p5ccf                                                              
```
