### PR TITLE
ansys: add 2022R2 version

### DIFF
--- a/templates/scitas/arvine.yaml.j2
+++ b/templates/scitas/arvine.yaml.j2
@@ -239,9 +239,7 @@
 {% if not 'cloud' in environment %}
 - external_packages:
   - adf@2017.111
-  - ansys@19.2
-  - ansys@2020R2
-  - ansys@2022R1
+  - ansys@2022R2
   - cfdplusplus@19.1
   - comsol@5.4
   - comsol@5.6

--- a/templates/scitas/packages-external-deprecated.yaml.j2
+++ b/templates/scitas/packages-external-deprecated.yaml.j2
@@ -16,10 +16,7 @@ adf:
 ansys:
   buildable: False
   paths:
-    ansys@17.1%{{environment.core_compiler}}: {{ spack_external_root }}/ansys/17.1/v171
-    ansys@19.2%{{environment.core_compiler}}: {{ spack_external_root }}/ansys/19.2/v192
-    ansys@2020R2%{{environment.core_compiler}}: {{ spack_external_root }}/ansys/2020R2/v202
-    ansys@2022R1%{{environment.core_compiler}}: {{ spack_external_root }}/ansys/2022R1/v221
+    ansys@2022R2%{{environment.core_compiler}}: {{ spack_external_root }}/ansys/2022R2/v222
 
 cfdplusplus:
   buildable: False

--- a/templates/scitas/packages-external.yaml.j2
+++ b/templates/scitas/packages-external.yaml.j2
@@ -18,12 +18,8 @@ adf:
 ansys:
   buildable: False
   externals:
-    - spec: "ansys@17.1%{{environment.core_compiler}}"
-      prefix: {{ spack_external_root }}/ansys/17.1/v171
-    - spec: "ansys@19.2%{{environment.core_compiler}}"
-      prefix: {{ spack_external_root }}/ansys/19.2/v192
-    - spec: "ansys@22.1%{{environment.core_compiler}}"
-      prefix: {{ spack_external_root }}/ansys/2022R1/v221
+    - spec: "ansys@22.2%{{environment.core_compiler}}"
+      prefix: {{ spack_external_root }}/ansys/2022R2/v222
 
 cfdplusplus:
   buildable: False


### PR DESCRIPTION
This commit also removes alder ansys versions which were no longer compatible with RHEL <= 8.4